### PR TITLE
Remove rules that are covered by stylelint-config-sass-guidelines

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,8 +9,6 @@
   "rules": {
     "max-nesting-depth": 2,
     "declaration-no-important": true,
-    "font-weight-notation": "named-where-possible",
-    "color-hex-length": "short",
-    "selector-pseudo-element-colon-notation": "double"
+    "font-weight-notation": "named-where-possible"
   }
 }


### PR DESCRIPTION
We can remove these two rules since they are duplicated in `stylelint-config-sass-guidelines`: 

```
"color-hex-length": "short",	
"selector-pseudo-element-colon-notation": "double"
```

