### PR TITLE
(change) add smaller font size

### DIFF
--- a/sass/vars/_typography.scss
+++ b/sass/vars/_typography.scss
@@ -18,6 +18,8 @@ $h2-font-size: 3.157rem;
 $h3-font-size: 2.369rem;
 $h4-font-size: 1.777rem;
 $h5-font-size: 1.333rem;
+
+$smaller-font-size: 16px;
 $tiny-text: 0.75rem;
 
 /* approx 72ch for base font size and HHGTTG reference */


### PR DESCRIPTION
Add smaller font size for uses such as `field-notes`

fix #121